### PR TITLE
Enhancement: More flexible bootstrap

### DIFF
--- a/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
+++ b/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
@@ -19,18 +19,19 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
 	/**
 	 * @var array Default config
 	 *
-	 * ['useInlineStylesBlock' => true] means that it will run setUseInlineStylesBlock(true) method of CssToInlineStyles:
+	 * array('useInlineStylesBlock' => TRUE)
+	 * means that setUseInlineStylesBlock(TRUE) method of CssToInlineStyles will be executed:
 	 * @see TijsVerkoyen\CssToInlineStyles\CssToInlineStyles::setUseInlineStylesBlock()
 	 */
-	protected $config = [
+	protected $config = array(
 		'useInlineStylesBlock' => TRUE,
-	];
+	);
 
 	/**
 	 * @param CssToInlineStyles|null $converter
 	 * @param array $options
 	 */
-	public function __construct(CssToInlineStyles $converter = null, array $options = [])
+	public function __construct(CssToInlineStyles $converter = null, array $options = array())
 	{
 		if ($converter)
 		{

--- a/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
+++ b/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
@@ -18,37 +18,38 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
 	private $converter;
 	/**
 	 * @var array Default config
-	 *
-	 * array('useInlineStylesBlock' => TRUE)
-	 * means that setUseInlineStylesBlock(TRUE) method of CssToInlineStyles will be executed:
-	 * @see TijsVerkoyen\CssToInlineStyles\CssToInlineStyles::setUseInlineStylesBlock()
 	 */
 	protected $config = array(
 		'useInlineStylesBlock' => TRUE,
 	);
 
 	/**
-	 * @param CssToInlineStyles|null $converter
-	 * @param array $options
+	 * @param CssToInlineStyles|array|null $dynamicParam
 	 */
-	public function __construct(CssToInlineStyles $converter = null, array $options = array())
+	public function __construct($dynamicParam = null)
 	{
-		if ($converter)
+		if ($dynamicParam instanceof CssToInlineStyles)
 		{
-			$this->converter = $converter;
+			$this->converter = $dynamicParam;
 		}
 		else
 		{
 			$this->converter = new CssToInlineStyles();
-		}
 
-		$this->config = array_merge($this->config, $options);
-		foreach ($this->config as $param => $val)
-		{
-			$methodName = 'set'.ucfirst($param);
-			if (method_exists($this->converter, $methodName))
+			if (is_array($dynamicParam))
 			{
-				$this->converter->$methodName($val);
+				$this->config = array_merge($this->config, $dynamicParam);
+			}
+			if (sizeof($this->config))
+			{
+				foreach ($this->config as $param => $val)
+				{
+					$methodName = 'set'.ucfirst($param);
+					if (method_exists($this->converter, $methodName))
+					{
+						$this->converter->$methodName($val);
+					}
+				}
 			}
 		}
 	}

--- a/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
+++ b/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
@@ -16,31 +16,38 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
 	 * @var CssToInlineStyles
 	 */
 	private $converter;
+	/**
+	 * @var array Default config
+	 *
+	 * ['useInlineStylesBlock' => true] means that it will run setUseInlineStylesBlock(true) method of CssToInlineStyles:
+	 * @see TijsVerkoyen\CssToInlineStyles\CssToInlineStyles::setUseInlineStylesBlock()
+	 */
+	protected $config = [
+		'useInlineStylesBlock' => TRUE,
+	];
 
 	/**
-	 * @param CssToInlineStyles|array|null $dynamicParam
+	 * @param CssToInlineStyles|null $converter
+	 * @param array $options
 	 */
-	public function __construct($dynamicParam = null)
+	public function __construct(CssToInlineStyles $converter = null, array $options = [])
 	{
-		if ($dynamicParam instanceof CssToInlineStyles)
+		if ($converter)
 		{
-			$this->converter = $dynamicParam;
+			$this->converter = $converter;
 		}
 		else
 		{
 			$this->converter = new CssToInlineStyles();
-			$this->converter->setUseInlineStylesBlock(TRUE);
+		}
 
-			if (is_array($dynamicParam) && sizeof($dynamicParam))
+		$this->config = array_merge($this->config, $options);
+		foreach ($this->config as $param => $val)
+		{
+			$methodName = 'set'.ucfirst($param);
+			if (method_exists($this->converter, $methodName))
 			{
-				foreach ($dynamicParam as $param => $val)
-				{
-					$methodName = 'set'.ucfirst($param);
-					if (method_exists($this->converter, $methodName))
-					{
-						$this->converter->$methodName($val);
-					}
-				}
+				$this->converter->$methodName($val);
 			}
 		}
 	}

--- a/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
+++ b/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
@@ -18,23 +18,35 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
 	private $converter;
 
 	/**
-	 * @param CssToInlineStyles $converter
+	 * @param CssToInlineStyles|array|null $dynamicParam
 	 */
-	public function __construct(CssToInlineStyles $converter = null)
+	public function __construct($dynamicParam = null)
 	{
-		if ($converter)
+		if ($dynamicParam instanceof CssToInlineStyles)
 		{
-			$this->converter = $converter;
+			$this->converter = $dynamicParam;
 		}
 		else
 		{
 			$this->converter = new CssToInlineStyles();
 			$this->converter->setUseInlineStylesBlock(TRUE);
+
+			if (is_array($dynamicParam) && sizeof($dynamicParam))
+			{
+				foreach ($dynamicParam as $param => $val)
+				{
+					$methodName = 'set'.ucfirst($param);
+					if (method_exists($this->converter, $methodName))
+					{
+						$this->converter->$methodName($val);
+					}
+				}
+			}
 		}
 	}
 
 	/**
-	 * @param Swift_Events_SendEvent $evt
+	 * @param \Swift_Events_SendEvent $evt
 	 */
 	public function beforeSendPerformed(\Swift_Events_SendEvent $evt)
 	{
@@ -65,7 +77,7 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
 	/**
 	 * Do nothing
 	 *
-	 * @param Swift_Events_SendEvent $evt
+	 * @param \Swift_Events_SendEvent $evt
 	 */
 	public function sendPerformed(\Swift_Events_SendEvent $evt)
 	{

--- a/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
+++ b/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
@@ -9,6 +9,14 @@ use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
  * @author     Ivan Kerin <ikerin@gmail.com>
  * @copyright  (c) 2013 OpenBuildings Ltd.
  * @license    http://spdx.org/licenses/BSD-3-Clause
+ *
+ * @method void setCleanup(bool $on = true)
+ * @method void setUseInlineStylesBlock(bool $on = true)
+ * @method void setStripOriginalStyleTags(bool $on = true)
+ * @method void setExcludeMediaQueries(bool $on = true)
+ * @method void setCss(string $css)
+ * @method void setEncoding(string $encoding)
+ * @method void setHTML(string $html)
  */
 class CssInlinerPlugin implements \Swift_Events_SendListener
 {
@@ -16,42 +24,38 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
 	 * @var CssToInlineStyles
 	 */
 	private $converter;
-	/**
-	 * @var array Default config
-	 */
-	protected $config = array(
-		'useInlineStylesBlock' => TRUE,
-	);
 
 	/**
-	 * @param CssToInlineStyles|array|null $dynamicParam
+	 * @param CssToInlineStyles $converter
 	 */
-	public function __construct($dynamicParam = null)
+	public function __construct(CssToInlineStyles $converter = null)
 	{
-		if ($dynamicParam instanceof CssToInlineStyles)
+		if ($converter)
 		{
-			$this->converter = $dynamicParam;
+			$this->converter = $converter;
 		}
 		else
 		{
 			$this->converter = new CssToInlineStyles();
-
-			if (is_array($dynamicParam))
-			{
-				$this->config = array_merge($this->config, $dynamicParam);
-			}
-			if (sizeof($this->config))
-			{
-				foreach ($this->config as $param => $val)
-				{
-					$methodName = 'set'.ucfirst($param);
-					if (method_exists($this->converter, $methodName))
-					{
-						$this->converter->$methodName($val);
-					}
-				}
-			}
+			$this->converter->setUseInlineStylesBlock(TRUE);
 		}
+	}
+
+	/**
+	 * Gives possibility to call CssToInlineStyles setters directly
+	 *
+	 * @param string $name method name
+	 * @param array $arguments method arguments
+	 * @return mixed
+	 */
+	public function __call($name, $arguments)
+	{
+		if ((substr($name, 0, 3) === 'set') && method_exists($this->converter, $name))
+		{
+			return call_user_func_array(array($this->converter, $name), $arguments);
+		}
+
+		trigger_error(sprintf('Call to undefined function: %s::%s().', get_class($this), $name), E_USER_ERROR);
 	}
 
 	/**


### PR DESCRIPTION
This will allow apart of 'converter injection' to initialize plugin this way: 

``` php
new CssInlinerPlugin([
    'cleanup' => true,
    'useInlineStylesBlock' => true,
    'stripOriginalStyleTags' => true,
]);
```

which is equivalent of this:

``` php
$converter = new CssToInlineStyles();
$converter->setCleanup(true);
$converter->setUseInlineStylesBlock(true);
$converter->setStripOriginalStyleTags(true);

new CssInlinerPlugin($converter);
```

Actually I suggest it for compatibility with Yii2 framework. With this change it's possible to enable CssInlinerPlugin in this easy way in Yii2 config file: 

``` php
return [
    'components' => [

        [...]

        /**
         * Mailer
         *
         * @link https://github.com/yiisoft/yii2-swiftmailer
         * @link http://swiftmailer.org/docs/messages.html
         */
        'mail' => [
            'class' => 'yii\swiftmailer\Mailer',
            'messageConfig' => [
                'charset' => 'utf-8',
            ],
            'transport' => [
                'class' => 'Swift_SmtpTransport',
                'host' => 'mail.domain.com',
                'username' => 'support@domain.com',
                'password' => '...',
                'plugins' => [
                    [
                        // connect CssInlinerPlugin
                        'class' => 'Openbuildings\Swiftmailer\CssInlinerPlugin',
                        // pass arguments to CssInlinerPlugin's constructor
                        'constructArgs' => [[
                            'cleanup' => true,
                            'useInlineStylesBlock' => true,
                            'stripOriginalStyleTags' => true,
                        ]],
                    ],
                ],
            ],
        ],
    ],
];

```

Existing implementation when CssToInlineStyles object is injected is already perfect.

I believe this change will be good addition that allow to use plugin in more flexible way (maybe other frameworks).

Thanks!
