### PR TITLE
Exclude mediaqueries by default

### DIFF
--- a/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
+++ b/src/Openbuildings/Swiftmailer/CssInlinerPlugin.php
@@ -30,6 +30,7 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
 		{
 			$this->converter = new CssToInlineStyles();
 			$this->converter->setUseInlineStylesBlock(TRUE);
+			$this->converter->setExcludeMediaQueries(TRUE);
 		}
 	}
 


### PR DESCRIPTION
Mediaqueries should usually not be inlined. This sets the correct default until https://github.com/tijsverkoyen/CssToInlineStyles/pull/69 is merged.
