### PR TITLE
Remove deprecated call to setEncoding

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -39,8 +39,6 @@ class CssInlinerPlugin implements Swift_Events_SendListener
 	{
 		$message = $event->getMessage();
 
-		$this->converter->setEncoding($message->getCharset());
-
 		if ($message->getContentType() === 'text/html') {
 			$this->converter->setCSS('');
 			$this->converter->setHTML($message->getBody());


### PR DESCRIPTION
For more informations you can take a look at this [pull request](https://github.com/tijsverkoyen/CssToInlineStyles/pull/74).