### PR TITLE
Upgrade tijsverkoyen/css-to-inline-styles to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - php: hhvm
   exclude:
     - php: hhvm
       env: DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require" : {
         "php": ">=5.4",
         "swiftmailer/swiftmailer": "^5.1",
-        "tijsverkoyen/css-to-inline-styles": "^1.5"
+        "tijsverkoyen/css-to-inline-styles": "^2.0"
     },
     "require-dev" : {
         "phpunit/phpunit": "^4.0|^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0d805b46f732274ab09a9094228e7bba",
-    "content-hash": "0ff1439587dfe758c4122794a14383f6",
+    "hash": "eede2da2205a68843a64d6e83de5721b",
+    "content-hash": "e2144471f29b1fc4dcb891525ff163bd",
     "packages": [
         {
             "name": "swiftmailer/swiftmailer",
@@ -112,29 +112,28 @@
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "1.5.4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "3065b197f54c83392a4e0ba355678a5080dd9ee2"
+                "reference": "bb535b05ba1e23a0400ecc73adaa00d37289baf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/3065b197f54c83392a4e0ba355678a5080dd9ee2",
-                "reference": "3065b197f54c83392a4e0ba355678a5080dd9ee2",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/bb535b05ba1e23a0400ecc73adaa00d37289baf1",
+                "reference": "bb535b05ba1e23a0400ecc73adaa00d37289baf1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "symfony/css-selector": "~2.1"
+                "symfony/css-selector": "^2.7|~3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.8|5.1.*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -144,7 +143,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -155,7 +154,7 @@
             ],
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
-            "time": "2015-04-01 14:40:03"
+            "time": "2016-02-23 13:27:47"
         }
     ],
     "packages-dev": [

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -28,7 +28,6 @@ class CssInlinerPlugin implements Swift_Events_SendListener
 			$this->converter = $converter;
 		} else {
 			$this->converter = new CssToInlineStyles();
-			$this->converter->setUseInlineStylesBlock(true);
 		}
 	}
 
@@ -40,18 +39,12 @@ class CssInlinerPlugin implements Swift_Events_SendListener
 		$message = $event->getMessage();
 
 		if ($message->getContentType() === 'text/html') {
-			$this->converter->setCSS('');
-			$this->converter->setHTML($message->getBody());
-
-			$message->setBody($this->converter->convert());
+			$message->setBody($this->converter->convert($message->getBody()));
 		}
 
 		foreach ($message->getChildren() as $part) {
 			if (strpos($part->getContentType(), 'text/html') === 0) {
-				$this->converter->setCSS('');
-				$this->converter->setHTML($part->getBody());
-
-				$part->setBody($this->converter->convert());
+				$part->setBody($this->converter->convert($part->getBody()));
 			}
 		}
 	}

--- a/tests/fixtures/emailConverted.html
+++ b/tests/fixtures/emailConverted.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
-<html><head><style>
+<html>
+  <head>
+    <style><![CDATA[
 			.block {
 				width: 100px;
 				height: 20px;
@@ -7,8 +9,10 @@
 			div.block ul li.small {
 				margin: 10px;
 			}
-		</style></head><body>
-		<div class="block" style="height: 20px; width: 100px;">
+		]]></style>
+  </head>
+  <body>
+		<div class="block" style="width: 100px; height: 20px;">
 			text
 
 			<ul><li>
@@ -18,4 +22,5 @@
 					Small list
 				</li>
 			</ul></div>
-	</body></html>
+	</body>
+</html>

--- a/tests/src/CssInlinerPluginTest.php
+++ b/tests/src/CssInlinerPluginTest.php
@@ -89,24 +89,6 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * @covers ::__construct
-	 */
-	public function testDefaultConverterUsesInlineStylesBlock()
-	{
-		$plugin = new CssInlinerPlugin();
-
-		$converter = PHPUnit_Framework_Assert::readAttribute($plugin, 'converter');
-
-		$this->assertTrue(
-			PHPUnit_Framework_Assert::readAttribute(
-				$converter,
-				'useInlineStylesBlock'
-			),
-			'setUseInlineStylesBlock() should be called on default $converter'
-		);
-	}
-
-	/**
-	 * @covers ::__construct
 	 * @covers ::beforeSendPerformed
 	 */
 	public function testInjectedConverterIsUsedInsteadOfDefault()


### PR DESCRIPTION
This would qualify as a breaking change, because we allow to pass an instance of the converter.
The API of the converter has changed.

While we can rely on users requiring the specific version of the converter library and Composer doing its job it's rare that people would require the correct version of sub-dependencies.

I would recommend people using the underlying converter library to make a conscious choice of upgrading.

Resolves #12.